### PR TITLE
fix: disable auto_enable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bluez (5.69-1deepin3) unstable; urgency=medium
+
+  * Disable auto enable.
+
+ -- Wang Yixue <wangyixue@deepin.org>  Wed, 28 Feb 2024 15:58:21 +0800
+
 bluez (5.69-1deepin2) unstable; urgency=medium
 
   * Add support for huawei haisi

--- a/debian/patches/main.conf.patch
+++ b/debian/patches/main.conf.patch
@@ -7,7 +7,7 @@ index 2796f155e..490abef65 100644
  # This includes adapters present on start as well as adapters that are plugged
  # in later on. Defaults to 'true'.
 -#AutoEnable=true
-+AutoEnable=true
- 
++AutoEnable=false
+
  # Audio devices that were disconnected due to suspend will be reconnected on
  # resume. ResumeDelay determines the delay between when the controller


### PR DESCRIPTION
Disable auto_enable in case that bluetooth adaptor is enabled by
default when system is installed for the first time.

Log: disable auto_enable
Issue: https://github.com/linuxdeepin/developer-center/issues/7243
