### PR TITLE
feat: bind obexd service lifecycle to graphical session

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bluez (5.85-3deepin6) unstable; urgency=medium
+
+  * Obexd exits immediately upon logout.
+
+ -- tunaichao <tunaichao@uniontech.com>  Wed, 18 Mar 2026 14:08:05 +0800
+
 bluez (5.85-3deepin5) unstable; urgency=medium
 
   * fix: Fix main conf for connection.

--- a/debian/patches/deepin-bug321717-Obexd-exits-immediately-upon-logout.patch
+++ b/debian/patches/deepin-bug321717-Obexd-exits-immediately-upon-logout.patch
@@ -1,0 +1,11 @@
+Index: bluez/obexd/src/obex.service.in
+===================================================================
+--- bluez.orig/obexd/src/obex.service.in
++++ bluez/obexd/src/obex.service.in
+@@ -1,5 +1,6 @@
+ [Unit]
+ Description=Bluetooth OBEX service
++PartOf=graphical-session.target
+ 
+ [Service]
+ Type=dbus

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@ main.conf.patch
 uniontech-add-custom-config-for-huawei.patch
 uniontech-add-sh-for-debug.patch
 deepin-bug282163-Fix-main-conf-for-connection.patch
+deepin-bug321717-Obexd-exits-immediately-upon-logout.patch


### PR DESCRIPTION
Added PartOf=graphical-session.target to obexd.service to ensure
obexd exits immediately upon user logout from graphical session.

适配v25系统，修复obexd登出后未退出的问题
在 obexd.service 中添加 PartOf=graphical-session.target，确保
用户登出图形会话时 obexd 服务立即退出，避免会话残留